### PR TITLE
Add KIS config

### DIFF
--- a/GameData/SmartParts/Parts/KISConfig.cfg
+++ b/GameData/SmartParts/Parts/KISConfig.cfg
@@ -1,0 +1,13 @@
+@KISConfig[*]
+{
+@StackableModule
+{
+moduleName = Valve
+moduleName = FuelController
+moduleName = Altimeter
+moduleName = RadioControl
+moduleName = Timer
+moduleName = ProxSensor
+moduleName = Stager
+}
+}


### PR DESCRIPTION
Config necessary for Kerbal Inventory System to allow parts to stack in
inventory.
Note that the Fuel Breakers are not present as they are too large to be
stackable.
File is only used if KIS is also installed on the same installation. This does not affect Smart Parts in any way.